### PR TITLE
Fix defsignal void function error

### DIFF
--- a/timp-server.el
+++ b/timp-server.el
@@ -45,6 +45,8 @@
 ;; (defvar threadS-stop nil
 ;;   "Thread will stop if it is set to t.")
 
+(require 'signal)
+
 (defconst timp-server-stream "timp-server-stream"
   "Process name of the data stream.
 Implement through localhost.")


### PR DESCRIPTION
If this library is loaded by itself before `signal`, `defsignal` will not be defined because `signal.el` hasn't been loaded, this fixes it.